### PR TITLE
Add custom favicon for site

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     
     <title>Eliseo Baroni</title>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2b6cb0" />
+      <stop offset="100%" stop-color="#63b3ed" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#grad)" />
+  <path d="M20 44l12-24 12 24" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="32" cy="44" r="4" fill="#ffffff" />
+</svg>


### PR DESCRIPTION
## Summary
- add a custom gradient favicon asset featuring the site's logo mark
- update the document head to reference the new favicon resource

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68db7f6cdea88325ac1f87fbab75c286